### PR TITLE
Add hasValue to PeopleFlowSensor

### DIFF
--- a/Ontology/Willow/Capability/Sensor/FlowSensor/PeopleFlowSensor/PeopleFlowSensor.json
+++ b/Ontology/Willow/Capability/Sensor/FlowSensor/PeopleFlowSensor/PeopleFlowSensor.json
@@ -8,7 +8,18 @@
     "dtmi:com:willowinc:FlowSensor;1"
   ],
   "contents": [
-
+    {
+      "@type": "Property",
+      "description": {
+        "en": "REC entities may be associated with values (e.g., Sensors, Setpoints, etc)."
+      },
+      "displayName": {
+        "en": "has value"
+      },
+      "name": "hasValue",
+      "schema": "double",
+      "writable": true
+    }
   ],
   "@context": "dtmi:dtdl:context;2"
 }


### PR DESCRIPTION
Updated PeopleFlowSensor to include the hasValue property because it isn't in any of the parent models.