### PR TITLE
Add connectorID to improve query perf

### DIFF
--- a/Ontology/Willow/Capability/Capability.json
+++ b/Ontology/Willow/Capability/Capability.json
@@ -61,6 +61,16 @@
       "schema": "string"
     },
     {
+      "@type": "Property",
+      "name": "connectorID",
+      "displayName": {
+        "en": "Connector ID"
+      },
+      "writable": true,
+      "schema": "string",
+      "comment": "Willow Connector identifier which manages the Capabiltiy"
+    },
+    {
       "@type": "Component",
       "name": "communication",
       "displayName": {


### PR DESCRIPTION
Adding connectorID as a property on Capability to allow a Willow Marketplace App to GET Capabilties by connectorID query by matching on property value instead of the hostedBy relationship with a connector/controller/gateway. This is needed to execute this query due to the maximum ADT allowable relationships to a node of 5,000.