### PR TITLE
Add scaleFactor

### DIFF
--- a/Ontology/Willow/Capability/Capability.json
+++ b/Ontology/Willow/Capability/Capability.json
@@ -179,6 +179,16 @@
     },
     {
       "@type": "Property",
+      "name": "scaleFactor",
+      "displayName": {
+        "en": "Scale Factor"
+      },
+      "writable": true,
+      "schema": "double",
+      "comment": "Raw values from the connected system are multiplied by this scale factor when being stored in the twin"
+    },
+    {
+      "@type": "Property",
       "name": "type",
       "displayName": {
         "en": "Type"


### PR DESCRIPTION
Added a scaleFactor to the base class Capability for the purpose of applying this at the edge prior to sending telemetry to the cloud.

Determined that we don't need an equivalent for shifting (+/-) at this time as this was not a stated requirement and would be handled by a more capable "expression handler" which can define order of operations and other more complex changes to the raw values.