### PR TITLE
Airport model migration

### DIFF
--- a/Ontology/Willow/Asset/Equipment/Airport/Aircraft Boarding/AircraftBoardingChair.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Aircraft Boarding/AircraftBoardingChair.json
@@ -1,0 +1,18 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AircraftBoardingChair;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Aircraft Boarding Chair"
+  },
+  "description": {
+    "en": "A device used to transfer passengers from their wheelchair or other apparatus to their seat in the aircraft cabin."
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AircraftBoardingEquipment;1"
+  ],
+  "contents": [
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Aircraft Boarding/AircraftBoardingEquipment.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Aircraft Boarding/AircraftBoardingEquipment.json
@@ -1,0 +1,15 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AircraftBoardingEquipment;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Aircraft Boarding Equipment"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirportEquipment;1"
+  ],
+  "contents": [
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Aircraft Boarding/PassengerBoardingBridge.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Aircraft Boarding/PassengerBoardingBridge.json
@@ -1,0 +1,18 @@
+{
+  "@id": "dtmi:com:willowinc:airport:PassengerBoardingBridge;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Passenger Boarding Bridge"
+  },
+  "description": {
+    "en": "An enclosed, movable connector which extends from an airport terminal gate to an airplane. Also commonly referred to as a jet bridge."
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AircraftBoardingEquipment;1"
+  ],
+  "contents": [
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Aircraft Boarding/PassengerBoardingLift.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Aircraft Boarding/PassengerBoardingLift.json
@@ -1,0 +1,18 @@
+{
+  "@id": "dtmi:com:willowinc:airport:PassengerBoardingLift;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Passenger Boarding Lift"
+  },
+  "description": {
+    "en": "A device that provides an elevating platform allowing the transfer of a person with disability or mobility impairment from the airport apron up to the aircraft door for boarding."
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AircraftBoardingEquipment;1"
+  ],
+  "contents": [
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Aircraft Boarding/PassengerBoardingRamp.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Aircraft Boarding/PassengerBoardingRamp.json
@@ -1,0 +1,18 @@
+{
+  "@id": "dtmi:com:willowinc:airport:PassengerBoardingRamp;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Passenger Boarding Ramp"
+  },
+  "description": {
+    "en": "A portable device used on an airport apron that provides a continous sloped surface from the ground to the aircraft doorsill height for passenger boarding."
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AircraftBoardingEquipment;1"
+  ],
+  "contents": [
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Aircraft Electrical/AircraftElectricalEquipment.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Aircraft Electrical/AircraftElectricalEquipment.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AircraftElectricalEquipment;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Aircraft Electrical Equipment"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirportEquipment;1",
+    "dtmi:com:willowinc:ElectricalEquipment;1"
+  ],
+  "contents": [
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Aircraft Electrical/AircraftGroundPowerUnit.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Aircraft Electrical/AircraftGroundPowerUnit.json
@@ -1,0 +1,18 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AircraftGroundPowerUnit;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Aircraft Ground Power Unit"
+  },
+  "description": {
+    "en": "A mobile or stationary device which provides electrical power to an aircraft between flights. (a.k.a. Aircraft GPU)"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AircraftElectricalEquipment;1"
+  ],
+  "contents": [
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Aircraft HVAC/AircraftHVACEquipment.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Aircraft HVAC/AircraftHVACEquipment.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AircraftHVACEquipment;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Aircraft HVAC Equipment"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirportEquipment;1",
+    "dtmi:com:willowinc:HVACEquipment;1"
+  ],
+  "contents": [
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Aircraft HVAC/AircraftPreconditionedAirUnit.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Aircraft HVAC/AircraftPreconditionedAirUnit.json
@@ -1,0 +1,18 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AircraftPreconditionedAirUnit;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Aircraft Preconditioned Air Unit"
+  },
+  "description": {
+    "en": "A device which provides fresh, preconditioned air to an aircraft and between flights. (a.k.a PCA Unit)."
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AircraftHVACEquipment;1"
+  ],
+  "contents": [
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/AirfieldLightingEquipment.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/AirfieldLightingEquipment.json
@@ -1,0 +1,146 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AirfieldLightingEquipment;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Lighting Equipment"
+  },
+  "extends": [
+    "dtmi:com:willowinc:airport:AirportEquipment;1",
+    "dtmi:com:willowinc:LightingEquipment;1"
+  ],
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "faaIntesityRating",
+      "displayName": {
+        "en": "FAA IntesityRating"
+      },
+      "writable": true,
+      "schema": {
+        "@type": "Enum",
+        "valueSchema": "string",
+        "enumValues": [
+          {
+            "name": "low",
+            "displayName": "Low",
+            "enumValue": "Low"
+          },
+          {
+            "name": "medium",
+            "displayName": "Medium",
+            "enumValue": "Medium"
+          },
+          {
+            "name": "high",
+            "displayName": "High",
+            "enumValue": "High"
+          }
+        ]
+      }
+    },
+    {
+      "@type": "Property",
+      "name": "installation",
+      "displayName": {
+        "en": "Installation"
+      },
+      "writable": true,
+      "schema": {
+        "@type": "Object",
+        "fields": [
+          {
+            "name": "type",
+            "displayName": {
+              "en": "Type"
+            },
+            "schema": {
+              "@type": "Enum",
+              "valueSchema": "string",
+              "enumValues": [
+                {
+                  "name": "elevated",
+                  "displayName": "Elevated",
+                  "enumValue": "Elevated"
+                },
+                {
+                  "name": "inset",
+                  "displayName": "Inset",
+                  "enumValue": "Inset"
+                }
+              ]
+            }
+          },
+          {
+            "name": "mounting",
+            "displayName": {
+              "en": "Mounting"
+            },
+            "schema": {
+              "@type": "Enum",
+              "valueSchema": "string",
+              "enumValues": [
+                {
+                  "name": "base",
+                  "displayName": "Base",
+                  "enumValue": "Base"
+                },
+                {
+                  "name": "stake",
+                  "displayName": "Stake",
+                  "enumValue": "Stake"
+                },
+                {
+                  "name": "direct",
+                  "displayName": "Direct",
+                  "enumValue": "Direct"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "@type": "Property",
+      "name": "lightDirection",
+      "displayName": {
+        "en": "Light Direction"
+      },
+      "writable": true,
+      "schema": {
+        "@type": "Enum",
+        "valueSchema": "string",
+        "enumValues": [
+          {
+            "name": "unidirectional",
+            "displayName": "Unidirectional",
+            "enumValue": "Unidirectional"
+          },
+          {
+            "name": "bidirectional",
+            "displayName": "Bidirectional",
+            "enumValue": "Bidirectional"
+          },
+          {
+            "name": "omnidirectional",
+            "displayName": "Omnidirectional",
+            "enumValue": "Omnidirectional"
+          }
+        ]
+      }
+    },
+    {
+      "@type": "Property",
+      "name": "lightColors",
+      "displayName": {
+        "en": "Light Colors"
+      },
+      "writable": true,
+      "schema": "string",
+      "comment": "yellow, white-white, red-green"
+    }
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Approach Light Fixture/ApproachLightFixture.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Approach Light Fixture/ApproachLightFixture.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:ApproachLightFixture;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Approach Light Fixture"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldLightingEquipment;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Approach Light Fixture/OmniDirectionalApproachLightFixture.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Approach Light Fixture/OmniDirectionalApproachLightFixture.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:OmniDirectionalApproachLightFixture;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Omni-Directional Approach Light (ODAL) Fixture"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:ApproachLightFixture;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Approach Light Fixture/PrecisionApproachPathIndicatorLightFixture.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Approach Light Fixture/PrecisionApproachPathIndicatorLightFixture.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:PrecisionApproachPathIndicatorLightFixture;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Precision Approach Path Indicator (PAPI) Light Fixture"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:ApproachLightFixture;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Approach Light Fixture/RunwayEndIdentifierLightFixture.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Approach Light Fixture/RunwayEndIdentifierLightFixture.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayEndIdentifierLightFixture;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway End Identifier Light (REIL) Fixture"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:ApproachLightFixture;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Obstruction Light Fixture/ObstructionLightFixture.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Obstruction Light Fixture/ObstructionLightFixture.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:ObstructionLightFixture;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Obstruction Light Fixture"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldLightingEquipment;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Rotating Beacon/RotatingBeacon.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Rotating Beacon/RotatingBeacon.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RotatingBeacon;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Rotating Beacon"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldLightingEquipment;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Runway Light Fixture/RunwayCenterlineLightFixture.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Runway Light Fixture/RunwayCenterlineLightFixture.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayCenterlineLightFixture;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway Centerline Light Fixture"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:RunwayLightFixture;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Runway Light Fixture/RunwayEdgeLightFixture.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Runway Light Fixture/RunwayEdgeLightFixture.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayEdgeLightFixture;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway Edge Light Fixture"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:RunwayLightFixture;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Runway Light Fixture/RunwayLightFixture.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Runway Light Fixture/RunwayLightFixture.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayLightFixture;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway Light Fixture"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldLightingEquipment;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Runway Light Fixture/RunwayTouchdownLightFixture.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Runway Light Fixture/RunwayTouchdownLightFixture.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayTouchdownLightFixture;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway Touchdown Light Fixture"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:RunwayLightFixture;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Taxiway Light Fixture/RunwayGuardLightFixture.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Taxiway Light Fixture/RunwayGuardLightFixture.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayGuardLightFixture;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway Guard Light Fixture"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:TaxiwayLightFixture;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Taxiway Light Fixture/RunwayStopBarGuardLightFixture.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Taxiway Light Fixture/RunwayStopBarGuardLightFixture.json
@@ -1,0 +1,17 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayStopBarGuardLightFixture;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Combination Runway Stop Bar - Runway Guard Light Fixture"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:RunwayStopBarLightFixture;1",
+    "dtmi:com:willowinc:airport:RunwayGuardLightFixture;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Taxiway Light Fixture/RunwayStopBarLightFixture.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Taxiway Light Fixture/RunwayStopBarLightFixture.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayStopBarLightFixture;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway Stop Bar Light Fixture"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:TaxiwayLightFixture;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Taxiway Light Fixture/TaxiwayCenterlineLightFixture.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Taxiway Light Fixture/TaxiwayCenterlineLightFixture.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:TaxiwayCenterlineLightFixture;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Taxiway Centerline Light Fixture"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:TaxiwayLightFixture;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Taxiway Light Fixture/TaxiwayEdgeLightFixture.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Taxiway Light Fixture/TaxiwayEdgeLightFixture.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:TaxiwayEdgeLightFixture;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Taxiway Edge Light Fixture"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:TaxiwayLightFixture;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Taxiway Light Fixture/TaxiwayLightFixture.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Lighting/Taxiway Light Fixture/TaxiwayLightFixture.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:TaxiwayLightFixture;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Taxiway Light Fixture"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldLightingEquipment;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/AirfieldSignageEquipment.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/AirfieldSignageEquipment.json
@@ -1,0 +1,112 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AirfieldSignageEquipment;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Airfield Signage Equipment"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirportEquipment;1"
+  ],
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "message",
+      "displayName": {
+        "en": "Message"
+      },
+      "writable": true,
+      "schema": "string",
+      "comment": "A | 36-18"
+    },
+    {
+      "@type": ["Property", "Length"],
+      "name": "messageHeight",
+      "displayName": {
+        "en": "Height"
+      },
+      "writable": true,
+      "schema": "double",
+      "unit": "millimetre"
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "message height unit"
+      },
+      "name": "messageHeightUnit",
+      "annotates": "messageHeight",
+      "overrides": "unit",
+      "schema": "LengthUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Length"],
+      "name": "panelHeight",
+      "displayName": {
+        "en": "Panel Height"
+      },
+      "writable": true,
+      "schema": "double",
+      "unit": "millimetre"
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "panel height unit"
+      },
+      "name": "panelHeightUnit",
+      "annotates": "panelHeight",
+      "overrides": "unit",
+      "schema": "LengthUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Length"],
+      "name": "panelWidth",
+      "displayName": {
+        "en": "Panel Width"
+      },
+      "writable": true,
+      "schema": "double",
+      "unit": "millimetre"
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "panel width unit"
+      },
+      "name": "panelWidthUnit",
+      "annotates": "panelWidth",
+      "overrides": "unit",
+      "schema": "LengthUnit",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "Length"],
+      "name": "installedHeight",
+      "displayName": {
+        "en": "Installed Height"
+      },
+      "writable": true,
+      "schema": "double",
+      "unit": "millimetre"
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "installed height unit"
+      },
+      "name": "installedHeightUnit",
+      "annotates": "installedHeight",
+      "overrides": "unit",
+      "schema": "LengthUnit",
+      "writable": true
+    }
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Boundary Sign/BoundarySign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Boundary Sign/BoundarySign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:BoundarySign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Boundary Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldSignageEquipment;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Boundary Sign/ILSCriticalAreaPOFZBoundarySign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Boundary Sign/ILSCriticalAreaPOFZBoundarySign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:ILSCriticalAreaPOFZBoundarySign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "ILS Critical Area / POFZ Boundary Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:BoundarySign;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Boundary Sign/RSAOFZRunwayApproachDepartureBoundarySign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Boundary Sign/RSAOFZRunwayApproachDepartureBoundarySign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RSAOFZRunwayApproachDepartureBoundarySign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "RSA/OFZ and Runway Approach/Departure Boundary Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:BoundarySign;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Destination Sign/DestinationSign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Destination Sign/DestinationSign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:DestinationSign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Destination Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldSignageEquipment;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Destination Sign/InboundDestinationSign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Destination Sign/InboundDestinationSign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:InboundDestinationSign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Inbound Destination Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:DestinationSign;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Destination Sign/OutboundDestinationSign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Destination Sign/OutboundDestinationSign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:OutboundDestinationSign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Outbound Destination Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:DestinationSign;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Direction Sign/DirectionSign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Direction Sign/DirectionSign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:DirectionSign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Direction Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldSignageEquipment;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Direction Sign/RunwayExitSign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Direction Sign/RunwayExitSign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayExitSign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway Exit Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:DirectionSign;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Direction Sign/TaxiwayDirectionSign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Direction Sign/TaxiwayDirectionSign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:TaxiwayDirectionSign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Taxiway Direction Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:DirectionSign;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Information Sign/InformationSign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Information Sign/InformationSign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:InformationSign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Information Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldSignageEquipment;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Information Sign/VORReceiverCheckpointSign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Information Sign/VORReceiverCheckpointSign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:VORReceiverCheckpointSign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "VOR Receiver Checkpoint Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:InformationSign;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Location Sign/LocationSign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Location Sign/LocationSign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:LocationSign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Location Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldSignageEquipment;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Location Sign/RunwayLocationSign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Location Sign/RunwayLocationSign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayLocationSign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway Location Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:LocationSign;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Location Sign/TaxiwayLocationSign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Location Sign/TaxiwayLocationSign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:TaxiwayLocationSign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Taxiway Location Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:LocationSign;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Mandatory Instruction Sign/Holding Position Sign/HoldingPositionSign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Mandatory Instruction Sign/Holding Position Sign/HoldingPositionSign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:HoldingPositionSign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Holding Position Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:MandatoryInstructionSign;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Mandatory Instruction Sign/Holding Position Sign/ILSCriticalAreaPOFZHoldingPositionSign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Mandatory Instruction Sign/Holding Position Sign/ILSCriticalAreaPOFZHoldingPositionSign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:ILSCriticalAreaPOFZHoldingPositionSign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "ILS Critical Area / POFZ Holding Position Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:HoldingPositionSign;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Mandatory Instruction Sign/Holding Position Sign/MilitaryLandingZoneHoldingPositionSign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Mandatory Instruction Sign/Holding Position Sign/MilitaryLandingZoneHoldingPositionSign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:MilitaryLandingZoneHoldingPositionSign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Military Landing Zone Holding Position Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:HoldingPositionSign;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Mandatory Instruction Sign/Holding Position Sign/RunwayApproachDepartureHoldingPositionSign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Mandatory Instruction Sign/Holding Position Sign/RunwayApproachDepartureHoldingPositionSign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayApproachDepartureHoldingPositionSign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway Approach/Departure Holding Position Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:HoldingPositionSign;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Mandatory Instruction Sign/Holding Position Sign/RunwayIntersectionHoldingPositionSign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Mandatory Instruction Sign/Holding Position Sign/RunwayIntersectionHoldingPositionSign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayIntersectionHoldingPositionSign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway Intersection Holding Position Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:HoldingPositionSign;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Mandatory Instruction Sign/MandatoryInstructionSign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Mandatory Instruction Sign/MandatoryInstructionSign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:MandatoryInstructionSign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Mandatory Instruction Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldSignageEquipment;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Mandatory Instruction Sign/NoEntrySign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Mandatory Instruction Sign/NoEntrySign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:NoEntrySign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "No Entry Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:MandatoryInstructionSign;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Runway Distance Remaining Sign/RunwayDistanceRemainingSign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Runway Distance Remaining Sign/RunwayDistanceRemainingSign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayDistanceRemainingSign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway Distance Remaining Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldSignageEquipment;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Runway Half Distance Remaining Sign/RunwayOneHalfDistanceRemainingSign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Runway Half Distance Remaining Sign/RunwayOneHalfDistanceRemainingSign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayOneHalfDistanceRemainingSign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway One-Half Distance Remaining Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldSignageEquipment;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Taxiway Ending Marker/TaxiwayEndingMarkerSign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Taxiway Ending Marker/TaxiwayEndingMarkerSign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:TaxiwayEndingMarkerSign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Taxiway Ending Marker Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldSignageEquipment;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Vehicle Roadway Sign/VehicleRoadwaySign.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Airfield Signage/Vehicle Roadway Sign/VehicleRoadwaySign.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:VehicleRoadwaySign;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Vehicle Roadway Sign"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldSignageEquipment;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/AirportEquipment.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/AirportEquipment.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AirportEquipment;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Airport Equipment"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:Equipment;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Baggage Handling/Baggage Conveyor/BaggageClaimCarousel.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Baggage Handling/Baggage Conveyor/BaggageClaimCarousel.json
@@ -1,0 +1,15 @@
+{
+  "@id": "dtmi:com:willowinc:airport:BaggageClaimCarousel;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Baggage Claim Carousel"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:BaggageConveyor;1"
+  ],
+  "contents": [
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Baggage Handling/Baggage Conveyor/BaggageConveyor.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Baggage Handling/Baggage Conveyor/BaggageConveyor.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:BaggageConveyor;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Baggage Conveyor"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:BaggageHandlingEquipment;1",    
+    "dtmi:com:willowinc:ConveyanceEquipment;1"
+  ],
+  "contents": [
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Baggage Handling/Baggage Conveyor/PassengerCheckInBaggageConveyor.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Baggage Handling/Baggage Conveyor/PassengerCheckInBaggageConveyor.json
@@ -1,0 +1,15 @@
+{
+  "@id": "dtmi:com:willowinc:airport:PassengerCheckInBaggageConveyor;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Passenger Check-In Baggage Conveyor"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:BaggageConveyor;1"
+  ],
+  "contents": [
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Baggage Handling/Baggage Screening/BaggageScreeningEquipment.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Baggage Handling/Baggage Screening/BaggageScreeningEquipment.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:BaggageScreeningEquipment;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Baggage Screening Equipment"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:BaggageHandlingEquipment;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Baggage Handling/BaggageHandlingEquipment.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Baggage Handling/BaggageHandlingEquipment.json
@@ -1,0 +1,15 @@
+{
+  "@id": "dtmi:com:willowinc:airport:BaggageHandlingEquipment;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Baggage Handling Equipment"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirportEquipment;1"
+  ],
+  "contents": [
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/Baggage Handling/BaggageScale/BaggageScale.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/Baggage Handling/BaggageScale/BaggageScale.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:BaggageScale;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Baggage Scale"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:BaggageHandlingEquipment;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/ICT/AirportICTEquipment.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/ICT/AirportICTEquipment.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AirportICTEquipment;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Airport ICT Equipment"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirportEquipment;1",
+    "dtmi:com:willowinc:ICTEquipment;1"
+  ],
+  "contents": [
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/ICT/AudioVisual/AirportAudioVisualEquipment.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/ICT/AudioVisual/AirportAudioVisualEquipment.json
@@ -1,0 +1,17 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AirportAudioVisualEquipment;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Airport Audio Visual Equipment"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirportICTEquipment;1",
+    "dtmi:com:willowinc:AudioVisualEquipment;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/ICT/AudioVisual/Display/AirportDisplay.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/ICT/AudioVisual/Display/AirportDisplay.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AirportDisplay;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Airport Display"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirportAudioVisualEquipment;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/ICT/AudioVisual/Display/FlightInformationDisplay.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/ICT/AudioVisual/Display/FlightInformationDisplay.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:FlightInformationDisplay;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Display"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirportDisplay;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Airport/WindCone.json
+++ b/Ontology/Willow/Asset/Equipment/Airport/WindCone.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:WindCone;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Wind Cone"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirportEquipment;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/Vehicle/VehicleEquipment.json
+++ b/Ontology/Willow/Asset/Equipment/Vehicle/VehicleEquipment.json
@@ -4,6 +4,9 @@
   "displayName": {
     "en": "Vehicle Equipment"
   },
+  "description": {
+    "en": "Equipment used to aid in the movement and operations of vehicles such as access control, parking, and dock loading."
+  },
   "extends" : [
     "dtmi:com:willowinc:Equipment;1"
   ],

--- a/Ontology/Willow/Asset/Vehicle/Airport/Aircraft/Aircraft.json
+++ b/Ontology/Willow/Asset/Vehicle/Airport/Aircraft/Aircraft.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:Aircraft;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Aircraft"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirportVehicle;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Vehicle/Airport/AirportVehicle.json
+++ b/Ontology/Willow/Asset/Vehicle/Airport/AirportVehicle.json
@@ -1,0 +1,19 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AirportVehicle;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Airport Vehicle"
+  },
+  "description": {
+    "en": "A vehicle at an aiport."
+  },
+  "extends" : [
+    "dtmi:com:willowinc:Vehicle;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Vehicle/Vehicle.json
+++ b/Ontology/Willow/Asset/Vehicle/Vehicle.json
@@ -1,0 +1,18 @@
+{
+  "@id": "dtmi:com:willowinc:Vehicle;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Vehicle"
+  },
+  "description": {
+    "en": "A mobile asset that is used to transport people and/or goods."
+  },
+  "extends" : [
+    "dtmi:com:willowinc:Asset;1"
+  ],
+  "contents": [
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Capability/State/Binary State/Dock State/AircraftDockState.json
+++ b/Ontology/Willow/Capability/State/Binary State/Dock State/AircraftDockState.json
@@ -1,0 +1,19 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AircraftDockState;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Aircraft Dock State"
+  },
+  "description": {
+    "en": "The Boolean state of the aircraft which is 'docked' when 'true' and 'not docked' when 'false'"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:BinaryState;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Collection/Asset Collection/Equipment/System/Airport/Airfield Lighting System/AirfieldLightingSystem.json
+++ b/Ontology/Willow/Collection/Asset Collection/Equipment/System/Airport/Airfield Lighting System/AirfieldLightingSystem.json
@@ -1,0 +1,17 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AirfieldLightingSystem;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Airfield Lighting System"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirportSystem;1",
+    "dtmi:com:willowinc:LightingSystem;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Collection/Asset Collection/Equipment/System/Airport/Airfield Lighting System/Approach Lighting System/ApproachLightingSystem.json
+++ b/Ontology/Willow/Collection/Asset Collection/Equipment/System/Airport/Airfield Lighting System/Approach Lighting System/ApproachLightingSystem.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:ApproachLightingSystem;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Approach Lighting System"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldLightingSystem;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Collection/Asset Collection/Equipment/System/Airport/Airfield Lighting System/Approach Lighting System/MediumIntensityApproachLightingSystem.json
+++ b/Ontology/Willow/Collection/Asset Collection/Equipment/System/Airport/Airfield Lighting System/Approach Lighting System/MediumIntensityApproachLightingSystem.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:MediumIntensityApproachLightingSystem;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Medium Intensity Approach Lighting System (MALS)"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:ApproachLightingSystem;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Collection/Asset Collection/Equipment/System/Airport/Airfield Lighting System/Approach Lighting System/OmniDirectionalApproachLightingSystem.json
+++ b/Ontology/Willow/Collection/Asset Collection/Equipment/System/Airport/Airfield Lighting System/Approach Lighting System/OmniDirectionalApproachLightingSystem.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:OmniDirectionalApproachLightingSystem;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Omni-Directional Approach Lighting System (ODALS)"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:ApproachLightingSystem;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Collection/Asset Collection/Equipment/System/Airport/Airfield Lighting System/LandAndHoldShortLightingSystem.json
+++ b/Ontology/Willow/Collection/Asset Collection/Equipment/System/Airport/Airfield Lighting System/LandAndHoldShortLightingSystem.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:LandAndHoldShortLightingSystem;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Land and Hold Short Lighting System"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldLightingSystem;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Collection/Asset Collection/Equipment/System/Airport/Airfield Lighting System/TaxiwayClearanceBar.json
+++ b/Ontology/Willow/Collection/Asset Collection/Equipment/System/Airport/Airfield Lighting System/TaxiwayClearanceBar.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:TaxiwayClearanceBar;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Taxiway Clearance Bar"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldLightingSystem;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Collection/Asset Collection/Equipment/System/Airport/AirportSystem.json
+++ b/Ontology/Willow/Collection/Asset Collection/Equipment/System/Airport/AirportSystem.json
@@ -1,0 +1,15 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AirportSystem;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Airport System"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:System;1"
+  ],
+  "contents": [
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Collection/Asset Collection/Equipment/System/Airport/Baggage Handling System/ArrivalBaggageHandlingSystem.json
+++ b/Ontology/Willow/Collection/Asset Collection/Equipment/System/Airport/Baggage Handling System/ArrivalBaggageHandlingSystem.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:ArrivalBaggageHandlingSystem;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Arrival Baggage Handling System"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:BaggageHandlingSystem;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Collection/Asset Collection/Equipment/System/Airport/Baggage Handling System/BaggageHandlingSystem.json
+++ b/Ontology/Willow/Collection/Asset Collection/Equipment/System/Airport/Baggage Handling System/BaggageHandlingSystem.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:BaggageHandlingSystem;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Baggage Handling System"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirportSystem;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Collection/Asset Collection/Equipment/System/Airport/Baggage Handling System/DepartureBaggageHandlingSystem.json
+++ b/Ontology/Willow/Collection/Asset Collection/Equipment/System/Airport/Baggage Handling System/DepartureBaggageHandlingSystem.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:DepartureBaggageHandlingSystem;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Departure Baggage Handling System"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:BaggageHandlingSystem;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Space/Airport/Airfield.json
+++ b/Ontology/Willow/Space/Airport/Airfield.json
@@ -1,0 +1,19 @@
+{
+  "@id": "dtmi:com:willowinc:airport:Airfield;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Airfield"
+  },
+  "description": {
+    "en": "The portion of the airport intended to be used wholly or in part for the arrival, departure, and movement of aircraft."
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirportSpace;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Space/Airport/AirportGate.json
+++ b/Ontology/Willow/Space/Airport/AirportGate.json
@@ -1,0 +1,45 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AiportGate;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Gate"
+  },
+  "description": {
+    "en": "An area in an airport terminal where passengers board the aircraft. Gates typically have a seated waiting area, counter, and doorway leading to the aircraft."
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirportSpace;1"
+  ],
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "coordinates",
+      "displayName": {
+        "en": "Coordinates"
+      },
+      "writable": true,
+      "schema": {
+        "@type": "Object",
+        "fields": [
+          {
+            "name": "latitude",
+            "displayName": {
+              "en": "Latitude"
+            },
+            "schema": "double"
+          },
+          {
+            "name": "longitude",
+            "displayName": {
+              "en": "Longitude"
+            },
+            "schema": "double"
+          }
+        ]
+      }
+    }
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Space/Airport/AirportSpace.json
+++ b/Ontology/Willow/Space/Airport/AirportSpace.json
@@ -1,0 +1,19 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AirportSpace;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Airport Space"
+  },
+  "description": {
+    "en": "A space that has a defined purpose to support the movement, management, and operations of people and vehicles at an airport."
+  },
+  "extends" : [
+    "dtmi:com:willowinc:Space;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Space/Airport/Apron.json
+++ b/Ontology/Willow/Space/Airport/Apron.json
@@ -1,0 +1,19 @@
+{
+  "@id": "dtmi:com:willowinc:airport:Apron;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Apron"
+  },
+  "description": {
+    "en": "A defined area on an airfield to accommodate aircraft for purposes of loading or unloading passengers, mail or cargo, fueling, parking, or maintenance."
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirportSpace;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Space/Airport/Runway.json
+++ b/Ontology/Willow/Space/Airport/Runway.json
@@ -1,0 +1,19 @@
+{
+  "@id": "dtmi:com:willowinc:airport:Runway;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway"
+  },
+  "description": {
+    "en": "A defined rectangular area on an airfield prepared for the landing and takeoff of aircraft."
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirportSpace;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Space/Airport/Taxiway.json
+++ b/Ontology/Willow/Space/Airport/Taxiway.json
@@ -1,0 +1,19 @@
+{
+  "@id": "dtmi:com:willowinc:airport:Taxiway;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Taxiway"
+  },
+  "description": {
+    "en": "A defined path on an airfield established for the taxiing of aircraft and intended to provide a link between one part of the airfield and another."
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirportSpace;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Space/Building/AirportTerminal.json
+++ b/Ontology/Willow/Space/Building/AirportTerminal.json
@@ -1,0 +1,20 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AirportTerminal;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Airport Terminal"
+  },
+  "description": {
+    "en": "A building at an airport where passengers transfer between ground transportation and the facilities that allow them to board and disembark from an aircraft."
+  },
+  "extends" : [
+    "dtmi:com:willowinc:Building;1",
+    "dtmi:com:willowinc:airport:AirportSpace;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Space/Land/Airport/AirBase.json
+++ b/Ontology/Willow/Space/Land/Airport/AirBase.json
@@ -1,0 +1,19 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AirBase;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Air Base"
+  },
+  "description": {
+    "en": "An airport used as a military base by a military force for the operation of military aircraft."
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:Airport;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Space/Land/Airport/Airport.json
+++ b/Ontology/Willow/Space/Land/Airport/Airport.json
@@ -1,0 +1,19 @@
+{
+  "@id": "dtmi:com:willowinc:airport:Airport;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Airport"
+  },
+  "description": {
+    "en": "A location where aircraft flight operations takes place that usually includes runways and maintenance facilities"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:Land;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Space/Land/Airport/Heliport.json
+++ b/Ontology/Willow/Space/Land/Airport/Heliport.json
@@ -1,0 +1,19 @@
+{
+  "@id": "dtmi:com:willowinc:airport:Heliport;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Heliport"
+  },
+  "description": {
+    "en": "An airport solely serving helicopters."
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:Airport;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Space/Land/Airport/SeaplaneBase.json
+++ b/Ontology/Willow/Space/Land/Airport/SeaplaneBase.json
@@ -1,0 +1,19 @@
+{
+  "@id": "dtmi:com:willowinc:airport:SeaplaneBase;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Seaplane Base"
+  },
+  "description": {
+    "en": "An airport that is located in a body of water, usually a river, bay, harbor, or lake, where seaplanes and amphibious aircraft take-off and land."
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:Airport;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Space/Parking Spot/AircraftParkingSpot.json
+++ b/Ontology/Willow/Space/Parking Spot/AircraftParkingSpot.json
@@ -1,0 +1,20 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AircraftParkingSpot;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Aircraft Parking Spot"
+  },
+  "description": {
+    "en": "A space intended for parking an aircraft to enplane/deplane passengers, load or unload cargo. Also referred to as an Aircraft Parking Position (FAA)."
+  },
+  "extends" : [
+    "dtmi:com:willowinc:ParkingSpot;1",
+    "dtmi:com:willowinc:airport:AirportSpace;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/AirfieldPavementMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/AirfieldPavementMarking.json
@@ -1,0 +1,25 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AirfieldPavementMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Airfield Pavement Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:PavementMarking;1"
+  ],
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "message",
+      "displayName": {
+        "en": "Message"
+      },
+      "writable": true,
+      "schema": "string",
+      "comment": "A | 36-18"
+    }
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Boundary Pavement Marking/AirfieldBoundaryPavementMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Boundary Pavement Marking/AirfieldBoundaryPavementMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AirfieldBoundaryPavementMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Airfield Boundary Pavement Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldPavementMarking;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Boundary Pavement Marking/AirfieldNonMovementAreaBoundaryMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Boundary Pavement Marking/AirfieldNonMovementAreaBoundaryMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AirfieldNonMovementAreaBoundaryMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Airfield Non-Movement Area Boundary Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldBoundaryPavementMarking;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Information Pavement Marking/AirfieldInformationPavementMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Information Pavement Marking/AirfieldInformationPavementMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AirfieldInformationPavementMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Airfield Information Pavement Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldPavementMarking;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Information Pavement Marking/AirfieldVORReceiverCheckpointSignMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Information Pavement Marking/AirfieldVORReceiverCheckpointSignMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AirfieldVORReceiverCheckpointSignMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Airfield VOR Receiver Checkpoint Sign Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldInformationPavementMarking;1"
+  ],
+  "contents": [
+
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Runway Pavement Marking/RunwayAimingPointMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Runway Pavement Marking/RunwayAimingPointMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayAimingPointMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway Aiming Point Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:RunwayPavementMarking;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Runway Pavement Marking/RunwayCenterlineMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Runway Pavement Marking/RunwayCenterlineMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayCenterlineMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway Centerline Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:RunwayPavementMarking;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Runway Pavement Marking/RunwayChevronMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Runway Pavement Marking/RunwayChevronMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayChevronMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway Chevron Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:RunwayPavementMarking;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Runway Pavement Marking/RunwayDemarcationBarMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Runway Pavement Marking/RunwayDemarcationBarMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayDemarcationBarMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway Demarcation Bar Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:RunwayPavementMarking;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Runway Pavement Marking/RunwayEdgeMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Runway Pavement Marking/RunwayEdgeMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayEdgeMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway Edge Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:RunwayPavementMarking;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Runway Pavement Marking/RunwayLandingDesignatorMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Runway Pavement Marking/RunwayLandingDesignatorMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayLandingDesignatorMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway Landing Designator Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:RunwayPavementMarking;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Runway Pavement Marking/RunwayPavementMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Runway Pavement Marking/RunwayPavementMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayPavementMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway Pavement Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldPavementMarking;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Runway Pavement Marking/RunwayShoulderMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Runway Pavement Marking/RunwayShoulderMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayShoulderMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway Shoulder Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:RunwayPavementMarking;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Runway Pavement Marking/RunwayThresholdBarMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Runway Pavement Marking/RunwayThresholdBarMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayThresholdBarMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway Threshold Bar Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:RunwayPavementMarking;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Runway Pavement Marking/RunwayThresholdMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Runway Pavement Marking/RunwayThresholdMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayThresholdMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway Threshold Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:RunwayPavementMarking;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Runway Pavement Marking/RunwayTouchdownZoneMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Runway Pavement Marking/RunwayTouchdownZoneMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:RunwayTouchdownZoneMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Runway Touchdown Zone Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:RunwayPavementMarking;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Taxiway Pavement Marking/TaxiwayApronControlMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Taxiway Pavement Marking/TaxiwayApronControlMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:TaxiwayApronControlMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Taxiway Apron Control Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:TaxiwayAirfieldPavementMarking;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Taxiway Pavement Marking/TaxiwayApronEntrancePointSignMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Taxiway Pavement Marking/TaxiwayApronEntrancePointSignMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:TaxiwayApronEntrancePointSignMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Taxiway Apron Entrance Point Sign Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:TaxiwayAirfieldPavementMarking;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Taxiway Pavement Marking/TaxiwayCenterlineMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Taxiway Pavement Marking/TaxiwayCenterlineMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:TaxiwayCenterlineMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Taxiway Centerline Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:TaxiwayAirfieldPavementMarking;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Taxiway Pavement Marking/TaxiwayDirectionSignMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Taxiway Pavement Marking/TaxiwayDirectionSignMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:TaxiwayDirectionSignMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Taxiway Direction Sign Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:TaxiwayAirfieldPavementMarking;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Taxiway Pavement Marking/TaxiwayEdgeMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Taxiway Pavement Marking/TaxiwayEdgeMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:TaxiwayEdgeMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Taxiway Edge Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:TaxiwayAirfieldPavementMarking;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Taxiway Pavement Marking/TaxiwayGateDesignationSignMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Taxiway Pavement Marking/TaxiwayGateDesignationSignMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:TaxiwayGateDesignationSignMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Taxiway Gate Designation Sign Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:TaxiwayAirfieldPavementMarking;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Taxiway Pavement Marking/TaxiwayGeographicPositionMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Taxiway Pavement Marking/TaxiwayGeographicPositionMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:TaxiwayGeographicPositionMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Taxiway Geographic Position Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:TaxiwayAirfieldPavementMarking;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Taxiway Pavement Marking/TaxiwayHoldingPositionSignMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Taxiway Pavement Marking/TaxiwayHoldingPositionSignMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:TaxiwayHoldingPositionSignMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Taxiway Holding Position Sign Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:TaxiwayAirfieldPavementMarking;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Taxiway Pavement Marking/TaxiwayLocationSignMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Taxiway Pavement Marking/TaxiwayLocationSignMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:TaxiwayLocationSignMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Taxiway Location Sign Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:TaxiwayAirfieldPavementMarking;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Taxiway Pavement Marking/TaxiwayPavementMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Taxiway Pavement Marking/TaxiwayPavementMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:TaxiwayAirfieldPavementMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Taxiway Pavement Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldPavementMarking;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Taxiway Pavement Marking/TaxiwayShoulderMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Taxiway Pavement Marking/TaxiwayShoulderMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:TaxiwayShoulderMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Taxiway Shoulder Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:TaxiwayAirfieldPavementMarking;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Vehicle Roadway Pavement Marking/AirfieldVehicleRoadwayPavementMarking.json
+++ b/Ontology/Willow/Structure/Pavement/Pavement Marking/Airfield/Vehicle Roadway Pavement Marking/AirfieldVehicleRoadwayPavementMarking.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:airport:AirfieldVehicleRoadwayPavementMarking;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Airfield Vehicle Roadway Pavement Marking"
+  },
+  "extends" : [
+    "dtmi:com:willowinc:airport:AirfieldPavementMarking;1"
+  ],
+  "contents": [
+    
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}


### PR DESCRIPTION
Migrating the airport ontology from the repository opendigitaltwins-airport into this common repository opendigitaltwins-building.