### PR TITLE
Added generic loop models

### DIFF
--- a/Ontology/Willow/Capability/Sensor/QuantitySensor/TemperatureSensor/Water/PrimaryLoopEnteringWaterTemperatureSensor.json
+++ b/Ontology/Willow/Capability/Sensor/QuantitySensor/TemperatureSensor/Water/PrimaryLoopEnteringWaterTemperatureSensor.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:PrimaryLoopEnteringWaterTemperatureSensor;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Primary Loop Entering Water Temperature Sensor"
+  },
+  "description": {"en": "The temperature feedback from a sensor associated with entering water on the primary side of a water loop"},
+  "extends" : [
+    "dtmi:com:willowinc:EnteringWaterTemperatureSensor;1"
+  ],
+  "contents": [
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Capability/Sensor/QuantitySensor/TemperatureSensor/Water/PrimaryLoopLeavingWaterTemperatureSensor.json
+++ b/Ontology/Willow/Capability/Sensor/QuantitySensor/TemperatureSensor/Water/PrimaryLoopLeavingWaterTemperatureSensor.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:PrimaryLoopLeavingWaterTemperatureSensor;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Primary Loop Leaving Water Temperature Sensor"
+  },
+  "description": {"en": "The temperature feedback from a sensor associated with leaving water on the primary side of a water loop"},
+  "extends" : [
+    "dtmi:com:willowinc:LeavingWaterTemperatureSensor;1"
+  ],
+  "contents": [
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Capability/Sensor/QuantitySensor/TemperatureSensor/Water/SecondaryLoopEnteringWaterTemperatureSensor.json
+++ b/Ontology/Willow/Capability/Sensor/QuantitySensor/TemperatureSensor/Water/SecondaryLoopEnteringWaterTemperatureSensor.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:SecondaryLoopEnteringWaterTemperatureSensor;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Secondary Loop Entering Water Temperature Sensor"
+  },
+  "description": {"en": "The temperature feedback from a sensor associated with entering water on the secondary side of a water loop"},
+  "extends" : [
+    "dtmi:com:willowinc:EnteringWaterTemperatureSensor;1"
+  ],
+  "contents": [
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Capability/Sensor/QuantitySensor/TemperatureSensor/Water/SecondaryLoopLeavingWaterTemperatureSensor.json
+++ b/Ontology/Willow/Capability/Sensor/QuantitySensor/TemperatureSensor/Water/SecondaryLoopLeavingWaterTemperatureSensor.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:SecondaryLoopLeavingWaterTemperatureSensor;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Secondary Loop Leaving Water Temperature Sensor"
+  },
+  "description": {"en": "The temperature feedback from a sensor associated with leaving water on the secondary side of a water loop"},
+  "extends" : [
+    "dtmi:com:willowinc:LeavingWaterTemperatureSensor;1"
+  ],
+  "contents": [
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}


### PR DESCRIPTION
With the new standard system modeling we likely wont need the system specific "loop" models like PrimaryLoopHotWaterEnteringTemperatureSensor but will still need the concept of Primary and Secondary models to use on heat exchangers which have a primary and secondary side. 

We could take this a step further and define a PrimaryLoopEnteringTemperatureSensor;1 without the specific designation for "water" since that can be determined from the medium property on the HX but that appears to be harder to work into the inheritance of the models we have in the ontology currently. 