### PR TITLE
Add connector app props

### DIFF
--- a/Ontology/Willow/Software/Application/ConnectorApplication.json
+++ b/Ontology/Willow/Software/Application/ConnectorApplication.json
@@ -63,9 +63,68 @@
           }
         ]
       }
+    },
+    {
+      "@type": "Property",
+      "name": "dataCollectionMethod",
+      "displayName": {
+        "en": "Data Collection Method"
+      },
+      "writable": true,
+      "schema": {
+        "@type": "Enum",
+        "valueSchema": "string",
+        "enumValues": [
+          {
+            "name": "polling",
+            "displayName": {
+              "en": "Polling"
+            },
+            "enumValue": "Polling"
+          },  
+          {
+            "name": "changeofValue",
+            "displayName": {
+              "en": "Change-of-Value"
+            },
+            "enumValue": "Change-of-Value"
+          },
+          {
+            "name": "changeOfValueWithHeartbeat",
+            "displayName": {
+              "en": "Change-of-Value with Heartbeat"
+            },
+            "enumValue": "Change-of-Value with Heartbeat"
+          }
+        ]
+      }
+    },
+    {
+      "@type": ["Property", "TimeSpan"],
+      "name": "pollingInterval",
+      "displayName": {
+        "en": "Polling Interval"
+      },
+      "writable": true,
+      "schema": "integer",
+      "unit": "second",
+      "comment": "how often the connector reads values from the controller(s)"
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "Polling Interval Unit"
+      },
+      "name": "pollingIntervalUnit",
+      "annotates": "pollingInterval",
+      "overrides": "unit",
+      "schema": "TimeUnit"
     }
   ],
   "@context": [
-    "dtmi:dtdl:context;3"
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
   ]
 }


### PR DESCRIPTION
Adding properties to identify polling vs COV -based connectors.

Discussion items:
* There is technically a difference between COV and event-based which doesn't have to be a change in value. Maybe the Cisco firehose would be an example where values can repeat? Important to capture these behavaior nuances?

* Capture a COV Increment property?