### PR TITLE
Add stale branch cleanup automation

### DIFF
--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -1,0 +1,30 @@
+# .github/workflows/stale-branches.yml
+# Automatically mark and delete stale branches to keep repository clean
+
+name: Stale Branches
+
+on:
+  schedule:
+    # Run weekdays at 6am UTC
+    - cron: '0 6 * * 1-5'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: write
+
+jobs:
+  stale_branches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stale Branches
+        uses: crs-k/stale-branches@v8.2.2
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          days-before-stale: 180        # Mark branch as stale after 180 days (6 months)
+          days-before-delete: 210       # Delete stale branch after 210 days total (7 months)
+          comment-updates: true          # Comment on issues when branch is marked stale
+          max-issues: 100                # Maximum number of issues to process per run
+          tag-committer: false           # Don't tag the committer in the issue
+          stale-branch-label: '[stale branch 🗑️]'  # Label for stale branch issues
+          compare-branches: 'save'       # Save branches for comparison


### PR DESCRIPTION
## Summary
Adds automated stale branch cleanup to help keep the repository clean and organized.

## Changes
- Added `.github/workflows/stale-branches.yml` workflow
- Configures automatic cleanup of branches inactive for 6+ months

## How It Works
1. **Day 0-180**: Branch is active, no action taken
2. **Day 180**: Branch marked as stale, GitHub issue created with `[stale branch 🗑️]` label
3. **Day 180-210**: 30-day grace period for manual review
4. **Day 210**: Branch automatically deleted if still inactive

## Configuration
- **Runs**: Weekdays at 6am UTC
- **Stale threshold**: 180 days (6 months)
- **Delete threshold**: 210 days (7 months)
- **Action**: Uses `crs-k/stale-branches@v8.2.2`

## Benefits
- Automatic cleanup of abandoned feature branches
- Reduces repository clutter (easier to find active branches)
- Improves repository performance
- Creates audit trail via GitHub issues
- 30-day grace period prevents accidental deletion
- Protected branches (main, release/*) automatically excluded

## Testing
- Can be manually triggered via workflow_dispatch
- Monitor GitHub issues with `[stale branch 🗑️]` label

Closes [AB#124302](https://dev.azure.com/willowdev/599df51c-122e-4f11-aebf-cf4ed69efe19/_workitems/edit/124302)

🤖 Generated with [Claude Code](https://claude.com/claude-code)