### PR TITLE
Max oa

### DIFF
--- a/Metadata/Willow.Ontology.DTDLv3.jsonld
+++ b/Metadata/Willow.Ontology.DTDLv3.jsonld
@@ -16416,6 +16416,34 @@
       {
         "@type": [
           "Property",
+          "VolumeFlowRate"
+        ],
+        "displayName": {
+          "en": "Design Maximum Outside Airflow"
+        },
+        "name": "designMaxOutsideAirflow",
+        "schema": "double",
+        "unit": "litrePerSecond",
+        "writable": true
+      },
+      {
+        "@type": [
+          "Property",
+          "ValueAnnotation",
+          "Override"
+        ],
+        "displayName": {
+          "en": "Design Maximum Outside Airflow Unit"
+        },
+        "name": "designMaxOutsideAirflowUnit",
+        "annotates": "designMaxOutsideAirflow",
+        "overrides": "unit",
+        "schema": "VolumeFlowRateUnit",
+        "writable": true
+      },
+      {
+        "@type": [
+          "Property",
           "Temperature"
         ],
         "name": "designMaxEnteringAirTemperature",

--- a/Ontology/Willow/Asset/Equipment/HVAC/Air Handling Unit/AirHandlingUnit.json
+++ b/Ontology/Willow/Asset/Equipment/HVAC/Air Handling Unit/AirHandlingUnit.json
@@ -220,6 +220,27 @@
       "schema": "VolumeFlowRateUnit",
       "writable": true
     },
+        {
+      "@type": ["Property", "VolumeFlowRate"],
+      "displayName": {
+        "en": "Design Maximum Outside Airflow"
+      },
+      "name": "designMaxOutsideAirflow",
+      "schema": "double",
+      "unit": "litrePerSecond",
+      "writable": true
+    },
+    {
+      "@type": ["Property", "ValueAnnotation", "Override"],
+      "displayName": {
+        "en": "Design Maximum Outside Airflow Unit"
+      },
+      "name": "designMaxOutsideAirflowUnit",
+      "annotates": "designMaxOutsideAirflow",
+      "overrides": "unit",
+      "schema": "VolumeFlowRateUnit",
+      "writable": true
+    },
     {
       "@type": [ "Property", "Temperature" ],
       "name": "designMaxEnteringAirTemperature",


### PR DESCRIPTION
This pull request adds new properties to support capturing the design maximum outside airflow and its unit for air handling units in both the ontology and its metadata. These additions help standardize how this important HVAC parameter is represented and annotated.

**Ontology and metadata enhancements:**

* Added the `designMaxOutsideAirflow` property (type: double, unit: litrePerSecond) to represent the design maximum outside airflow in both the `AirHandlingUnit.json` ontology and the `Willow.Ontology.DTDLv3.jsonld` metadata. [[1]](diffhunk://#diff-e56106bdbd9485799ff7d19bf9a2a1abd239cca45804e0d80a3c105cc2f68aa4R222-R242) [[2]](diffhunk://#diff-4d0d7b9140748fe8892b97709d3a9c8f9b123242f4123e966106a2c415993cf8R16416-R16443)
* Added the `designMaxOutsideAirflowUnit` property as a value annotation and override, allowing the unit for the design maximum outside airflow to be explicitly specified or overridden. [[1]](diffhunk://#diff-e56106bdbd9485799ff7d19bf9a2a1abd239cca45804e0d80a3c105cc2f68aa4R222-R242) [[2]](diffhunk://#diff-4d0d7b9140748fe8892b97709d3a9c8f9b123242f4123e966106a2c415993cf8R16416-R16443)