### PR TITLE
Added Fuel Type to Boiler

### DIFF
--- a/Ontology/Willow/Asset/Equipment/Plumbing/Boiler/Boiler.json
+++ b/Ontology/Willow/Asset/Equipment/Plumbing/Boiler/Boiler.json
@@ -219,6 +219,31 @@
       },
       "schema": "double",
       "writable": true
+    },
+    {
+      "@type": "Property",
+      "name": "fuelType",
+      "displayName": {
+        "en": "fuel type"
+      },
+      "description": {
+        "en": "The fuel the boiler consumes to produce heat. Used by downstream systems to apply the appropriate utility rate (electricity vs natural gas) for heating-energy cost calculations."
+      },
+      "schema": {
+        "@type": "Enum",
+        "enumValues": [
+          {
+            "enumValue": "Electric",
+            "name": "Electric"
+          },
+          {
+            "enumValue": "NaturalGas",
+            "name": "NaturalGas"
+          }
+        ],
+        "valueSchema": "string"
+      },
+      "writable": true
     }
   ],
   "@context": [


### PR DESCRIPTION
This pull request adds a new property to the boiler equipment ontology to specify the type of fuel the boiler uses. This addition will help downstream systems correctly apply utility rates for heating energy cost calculations.

**Enhancements to Boiler Ontology:**

* Added a new `fuelType` property to the `Boiler.json` ontology, allowing specification of the boiler's fuel as either "Electric" or "NaturalGas". This supports more accurate downstream energy cost calculations by distinguishing between electricity and natural gas usage.