### PR TITLE
New RPM model

### DIFF
--- a/Ontology/Willow/Asset/Equipment/ICT/Sensor/RoomPressureMonitorEquipment.json
+++ b/Ontology/Willow/Asset/Equipment/ICT/Sensor/RoomPressureMonitorEquipment.json
@@ -1,0 +1,18 @@
+{
+  "@id": "dtmi:com:willowinc:RoomPressureMonitorEquipment;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Room Pressure Monitor Equipment"
+  },
+  "description": {
+    "en": "A device installed at a room that measures and reports the differential (delta) air pressure between the room and an adjacent reference space, typically providing a local display and alarm. Commonly used to verify pressurization of critical environments such as hospital isolation rooms, operating rooms, pharmacy cleanrooms, and laboratories."
+  },
+  "extends": [
+    "dtmi:com:willowinc:PressureSensorEquipment;1"
+  ],
+  "contents": [
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Asset/Equipment/ICT/Sensor/RoomPressureMonitorEquipment.json
+++ b/Ontology/Willow/Asset/Equipment/ICT/Sensor/RoomPressureMonitorEquipment.json
@@ -1,8 +1,8 @@
 {
-  "@id": "dtmi:com:willowinc:RoomPressureMonitorEquipment;1",
+  "@id": "dtmi:com:willowinc:RoomPressureMonitor;1",
   "@type": "Interface",
   "displayName": {
-    "en": "Room Pressure Monitor Equipment"
+    "en": "Room Pressure Monitor"
   },
   "description": {
     "en": "A device installed at a room that measures and reports the differential (delta) air pressure between the room and an adjacent reference space, typically providing a local display and alarm. Commonly used to verify pressurization of critical environments such as hospital isolation rooms, operating rooms, pharmacy cleanrooms, and laboratories."


### PR DESCRIPTION
This pull request introduces a new digital twin interface for room pressure monitoring equipment. The new interface extends the existing pressure sensor equipment ontology and provides metadata for devices that measure and report differential air pressure in critical environments.

**Ontology extension:**

* Added a new interface definition `RoomPressureMonitorEquipment` in `Sensor/RoomPressureMonitorEquipment.json`, including display name, description, and context, and extending `PressureSensorEquipment`.