### PR TITLE
Update to Add HVAC Compressor Group

### DIFF
--- a/Ontology/Willow/Asset/Equipment/HVAC/Chiller/Chiller.json
+++ b/Ontology/Willow/Asset/Equipment/HVAC/Chiller/Chiller.json
@@ -22,9 +22,6 @@
         "en": "Compressor"
       },
       "name": "compressor",
-      "description": {
-        "en": "Singular embedded compressor for simple single-compressor chillers. Multi-compressor and multi-circuit chillers instead model each compressor as a standalone Compressor twin via includedIn an HVACCompressorGroup (one group per refrigerant circuit)."
-      },
       "schema": "dtmi:com:willowinc:Compressor;1"
     },
     {

--- a/Ontology/Willow/Asset/Equipment/HVAC/Chiller/Chiller.json
+++ b/Ontology/Willow/Asset/Equipment/HVAC/Chiller/Chiller.json
@@ -22,6 +22,9 @@
         "en": "Compressor"
       },
       "name": "compressor",
+      "description": {
+        "en": "Singular embedded compressor for simple single-compressor chillers. Multi-compressor and multi-circuit chillers instead model each compressor as a standalone Compressor twin via includedIn an HVACCompressorGroup (one group per refrigerant circuit)."
+      },
       "schema": "dtmi:com:willowinc:Compressor;1"
     },
     {

--- a/Ontology/Willow/Collection/Asset Collection/Equipment/Equipment Group/HVAC/HVACCompressorGroup.json
+++ b/Ontology/Willow/Collection/Asset Collection/Equipment/Equipment Group/HVAC/HVACCompressorGroup.json
@@ -5,7 +5,7 @@
     "en": "HVAC Compressor Group"
   },
   "description": {
-    "en": "A group of compressors forming one refrigerant circuit of an HVAC refrigeration machine (e.g. a chiller), piped in parallel on a shared suction/discharge manifold and refrigerant/oil charge, operating together as a single staged entity. One group per refrigerant circuit. The HVAC-domain analog of RefrigerationCompressorRack / RefrigerationCompressorGroup. Hosts the per-circuit refrigerant points (suction/discharge pressure and saturated temperature); individual compressors are members via the includes/includedIn relationship."
+    "en": "A group of compressors forming one refrigerant circuit of an HVAC refrigeration machine (e.g. a chiller), piped in parallel on a shared suction/discharge manifold and refrigerant/oil charge, operating together as a single staged entity. One group per refrigerant circuit. The HVAC-domain analog of RefrigerationCompressorRack / RefrigerationCompressorGroup. Hosts the per-circuit refrigerant points (suction/discharge pressure and saturated temperature); individual compressors are members via the includedIn relationship."
   },
   "extends": [
     "dtmi:com:willowinc:HVACEquipmentGroup;1"

--- a/Ontology/Willow/Collection/Asset Collection/Equipment/Equipment Group/HVAC/HVACCompressorGroup.json
+++ b/Ontology/Willow/Collection/Asset Collection/Equipment/Equipment Group/HVAC/HVACCompressorGroup.json
@@ -1,0 +1,30 @@
+{
+  "@id": "dtmi:com:willowinc:HVACCompressorGroup;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "HVAC Compressor Group"
+  },
+  "description": {
+    "en": "A group of compressors forming one refrigerant circuit of an HVAC refrigeration machine (e.g. a chiller), piped in parallel on a shared suction/discharge manifold and refrigerant/oil charge, operating together as a single staged entity. One group per refrigerant circuit. The HVAC-domain analog of RefrigerationCompressorRack / RefrigerationCompressorGroup. Hosts the per-circuit refrigerant points (suction/discharge pressure and saturated temperature); individual compressors are members via the includes/includedIn relationship."
+  },
+  "extends": [
+    "dtmi:com:willowinc:HVACEquipmentGroup;1"
+  ],
+  "contents": [
+    {
+      "@type": "Property",
+      "displayName": {
+        "en": "Number of Compressors"
+      },
+      "name": "numberOfCompressors",
+      "description": {
+        "en": "The count of compressors piped in parallel on this circuit / manifold. Configuration value; should equal the number of Compressor twins included in this group."
+      },
+      "schema": "integer",
+      "writable": true
+    }
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Collection/Asset Collection/Equipment/Equipment Group/HVAC/HVACCompressorGroup.json
+++ b/Ontology/Willow/Collection/Asset Collection/Equipment/Equipment Group/HVAC/HVACCompressorGroup.json
@@ -5,24 +5,12 @@
     "en": "HVAC Compressor Group"
   },
   "description": {
-    "en": "A group of compressors forming one refrigerant circuit of an HVAC refrigeration machine (e.g. a chiller), piped in parallel on a shared suction/discharge manifold and refrigerant/oil charge, operating together as a single staged entity. One group per refrigerant circuit. The HVAC-domain analog of RefrigerationCompressorRack / RefrigerationCompressorGroup. Hosts the per-circuit refrigerant points (suction/discharge pressure and saturated temperature); individual compressors are members via the includes/includedIn relationship."
+    "en": "A group of compressors forming one refrigerant circuit of an HVAC refrigeration machine (e.g. a chiller), piped in parallel on a shared suction/discharge manifold and refrigerant/oil charge, operating together as a single staged entity. One group per refrigerant circuit. The HVAC-domain analog of RefrigerationCompressorRack / RefrigerationCompressorGroup. Hosts the per-circuit refrigerant points (suction/discharge pressure and saturated temperature); individual compressors are members via the includedIn relationship (compressor includedIn this group)."
   },
   "extends": [
     "dtmi:com:willowinc:HVACEquipmentGroup;1"
   ],
   "contents": [
-    {
-      "@type": "Property",
-      "displayName": {
-        "en": "Number of Compressors"
-      },
-      "name": "numberOfCompressors",
-      "description": {
-        "en": "The count of compressors piped in parallel on this circuit / manifold. Configuration value; should equal the number of Compressor twins included in this group."
-      },
-      "schema": "integer",
-      "writable": true
-    }
   ],
   "@context": [
     "dtmi:dtdl:context;3"


### PR DESCRIPTION
This pull request introduces a new `HVACCompressorGroup` interface and clarifies how compressors are modeled in the chiller ontology. The changes improve the representation of multi-compressor and multi-circuit chillers by organizing compressors into groups and documenting the modeling approach.

**New HVAC Compressor Group modeling:**

* Added a new `HVACCompressorGroup` interface (`HVACCompressorGroup.json`) to represent a group of compressors forming one refrigerant circuit, including a property for the number of compressors and a detailed description of its role and relationships.

**Chiller compressor modeling clarification:**

* Updated the `compressor` component in `Chiller.json` to include a description explaining when to use the embedded compressor versus modeling each compressor as a standalone twin in a group, clarifying best practices for single- and multi-compressor chillers.