### PR TITLE
Adding Open or Closed Override Actuators

### DIFF
--- a/Ontology/Willow/Capability/Actuator/Binary Actuator/DefaultOverride Actuator/Override Actuator/CloseOverrideActuator.json
+++ b/Ontology/Willow/Capability/Actuator/Binary Actuator/DefaultOverride Actuator/Override Actuator/CloseOverrideActuator.json
@@ -4,7 +4,7 @@
   "displayName": {
     "en": "Close Override Actuator"
   },
-  "description": {"en": "The Boolean command which overrides the state of the equipment to 'close' when 'true'"},
+  "description": {"en": "The Boolean command which overrides the 'close' command of the equipment when 'true'"},
   "extends" : [
     "dtmi:com:willowinc:OverrideActuator;1"
   ],

--- a/Ontology/Willow/Capability/Actuator/Binary Actuator/DefaultOverride Actuator/Override Actuator/CloseOverrideActuator.json
+++ b/Ontology/Willow/Capability/Actuator/Binary Actuator/DefaultOverride Actuator/Override Actuator/CloseOverrideActuator.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:CloseOverrideActuator;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Close Override Actuator"
+  },
+  "description": {"en": "The Boolean command which overrides the state of the equipment to 'close' when 'true'"},
+  "extends" : [
+    "dtmi:com:willowinc:OverrideActuator;1"
+  ],
+  "contents": [
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Capability/Actuator/Binary Actuator/DefaultOverride Actuator/Override Actuator/OpenOverrideActuator.json
+++ b/Ontology/Willow/Capability/Actuator/Binary Actuator/DefaultOverride Actuator/Override Actuator/OpenOverrideActuator.json
@@ -1,0 +1,16 @@
+{
+  "@id": "dtmi:com:willowinc:OpenOverrideActuator;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Open Override Actuator"
+  },
+  "description": {"en": "The Boolean command which overrides the state of the equipment to 'open' when 'true'"},
+  "extends" : [
+    "dtmi:com:willowinc:OverrideActuator;1"
+  ],
+  "contents": [
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ]
+}

--- a/Ontology/Willow/Capability/Actuator/Binary Actuator/DefaultOverride Actuator/Override Actuator/OpenOverrideActuator.json
+++ b/Ontology/Willow/Capability/Actuator/Binary Actuator/DefaultOverride Actuator/Override Actuator/OpenOverrideActuator.json
@@ -4,7 +4,7 @@
   "displayName": {
     "en": "Open Override Actuator"
   },
-  "description": {"en": "The Boolean command which overrides the state of the equipment to 'open' when 'true'"},
+  "description": {"en": "The Boolean command which overrides the 'open' command of the equipment when 'true'"},
   "extends" : [
     "dtmi:com:willowinc:OverrideActuator;1"
   ],


### PR DESCRIPTION
This pull request introduces two new Digital Twin Definition Language (DTDL) interface definitions for override actuators that control binary equipment states. Specifically, it adds separate actuator interfaces for overriding equipment to either an "open" or "close" state.

New actuator interface definitions:

* Added `CloseOverrideActuator` interface, representing a Boolean command to override equipment to the "close" state when set to true. (`Ontology/Willow/Capability/Actuator/Binary Actuator/DefaultOverride Actuator/Override Actuator/CloseOverrideActuator.json`)
* Added `OpenOverrideActuator` interface, representing a Boolean command to override equipment to the "open" state when set to true. (`Ontology/Willow/Capability/Actuator/Binary Actuator/DefaultOverride Actuator/Override Actuator/OpenOverrideActuator.json`)