### PR TITLE
Widen AssetComponent isPartOf to allow a Collection target

### DIFF
--- a/Ontology/Willow/Component/Asset/AssetComponent.json
+++ b/Ontology/Willow/Component/Asset/AssetComponent.json
@@ -14,13 +14,12 @@
     {
       "@type": "Relationship",
       "description": {
-        "en": "Indicates a super-entity of the same base type (i.e., Spaces only have Spaces as parents, Organizations only have Organizations, etc)."
+        "en": "Indicates the Asset or Asset Collection (e.g. an equipment group such as an HVACHeatExchangerGroup) that this component is a constituent part of. Untyped because a component's composing entity can be either an Asset or a Collection, and DTDL relationship targets cannot express a union of both."
       },
       "displayName": {
         "en": "is part of"
       },
-      "name": "isPartOf",
-      "target": "dtmi:com:willowinc:Asset;1"
+      "name": "isPartOf"
     },
     {
       "@type": "Relationship",


### PR DESCRIPTION
## Summary
`AssetComponent;1`'s `isPartOf` relationship was hard-typed to `dtmi:com:willowinc:Asset;1`. `Asset;1` and `Collection;1` are separate root interfaces with no common ancestor in this ontology (`extends: []` on both), so an `AssetComponent` could never be validly `isPartOf` a `Collection` such as an equipment group.

This blocks the `HeatExchangerPrimarySide`/`HeatExchangerSecondarySide` component pattern for `HVACHeatExchangerGroup`: those components extend `AssetComponent` (via `HeatExchangerSide`), and `HVACHeatExchangerGroup` is a `Collection` (`HVACEquipmentGroup` -> `EquipmentGroup` -> `EquipmentCollection` -> `AssetCollection` -> `Collection`), not an `Asset` - so the `isPartOf` relationship the migration needs to create between a new side component twin and its `HVACHeatExchangerGroup` was rejected by the type constraint.

DTDL relationship targets can't express a union of two unrelated interfaces, so the fix drops `target` entirely, making `isPartOf` untyped - matching the sibling `isFedBy` relationship already on the same `AssetComponent` interface, which has no target restriction. Updated the `description` text to describe both valid targets in place of the old "same base type only" wording, since that description no longer matches the (deliberately) widened intent.

This change is purely permissive - dropping a type constraint can only make previously-invalid modeling become valid, it cannot invalidate anything that validated before.

## Context
Reported by Joe Augustine via Rick Szcodronski in the "Clarification on isParameterOf" Teams thread: Joe's migration of 34 `HeatExchangerPrimarySide`/`HeatExchangerSecondarySide` twins across 32 `HVACHeatExchangerGroup` instances (nau 24, brk 9, inv 1) - following [WillowSkills/RulesLibrary#1018](https://github.com/WillowSkills/RulesLibrary/pull/1018) - was failing on this constraint.

## Test plan
- [x] Confirmed `Asset;1` and `Collection;1` are both root interfaces (`extends: []`) with no shared ancestor, so no narrower `target` value could satisfy both cases
- [x] Confirmed the sibling `isFedBy` relationship on `AssetComponent;1` already has no `target` restriction, so this isn't introducing a new pattern to the interface
- [x] JSON syntax validated
- [ ] Joe Augustine to confirm this unblocks the pending migration once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)